### PR TITLE
Implement event ranges

### DIFF
--- a/cups.py
+++ b/cups.py
@@ -271,6 +271,32 @@ def nevents(args):
         statusdbc.execute( update )
         statusdbc.commit()
 
+#_______________________________________________________________________________________________________
+@subcommand([
+    argument(     "--files",  help="List of input files (and/or ranges)",dest="files",nargs="+"),
+])
+def inputs(args):
+    """
+    Updates the number of events processed
+    """
+    tablename=args.table
+    dstname=args.dstname
+    run=int(args.run)
+    seg=int(args.segment)
+    id_ = getLatestId( tablename, dstname, run, seg )
+    inputs = ' '.join(args.files)
+    update = f"""
+    update {tablename}
+    set inputs='{inputs}'
+    where dstname='{dstname}' and run={run} and segment={seg} and id={id_}
+    """
+    if args.noupdate:
+        print(update)
+    else:
+        print(update)
+        statusdbc.execute( update )
+        statusdbc.commit()
+
 
 # files
 # lfn | full_host_name | full_file_path | time | size | md5 

--- a/cups.py
+++ b/cups.py
@@ -15,10 +15,6 @@ import sys
 import signal
 import json
 
-# File catalog
-fc = pyodbc.connect("DSN=FileCatalog;UID=phnxrc")
-fcc = fc.cursor()
-
 # Production status ... TODO: refactor production_status table to use "ps" and "psc"... to support different DB's...
 statusdb = pyodbc.connect("DSN=FileCatalog")
 statusdbc = statusdb.cursor()
@@ -313,6 +309,10 @@ def catalog(args):
 
     filename = f"{dstname}-{run:08}-{seg:04}.{ext}"
 
+    # File catalog
+    fc = pyodbc.connect("DSN=FileCatalog;UID=phnxrc")
+    fcc = fc.cursor()
+
     checkfile = fcc.execute( f"select size,full_file_path from files where lfn='{filename}';" ).fetchall()
     if checkfile and replace:
         fcc.execute(f"delete from files where lfn='{filename}';")
@@ -408,7 +408,10 @@ def quality(args):
     INSERT INTO production_quality (stat_id,dstname,run,segment,qual) values
       ( {id_},'{dstname}',{run},{segment},'{qastring}' );   
     """
-    print(qaentry)
+
+    # File catalog
+    fc = pyodbc.connect("DSN=FileCatalog;UID=phnxrc")
+    fcc = fc.cursor()
 
     fcc.execute(qaentry)
     fcc.commit()    

--- a/kaedama.py
+++ b/kaedama.py
@@ -83,7 +83,7 @@ def main():
     input_         = config.get('input')
     input_query    = input_.get('query','').format(**locals())
     input_query_db = input_.get('db',None)
-    #input_query   = config.get('input_query','').format(**locals())
+
     runlist_query = config.get('runlist_query','').format(**locals())
     params        = config.get('params',None)
     filesystem    = config.get('filesystem',None)
@@ -138,6 +138,7 @@ def main():
     if args.submit and params and input_query and filesystem and job:
         dst_rule = Rule( name              = params['name'],
                          files             = input_query,
+                         filesdb           = input_query_db,
                          runlist           = runlist_query,            # may be None
                          script            = params['script'],
                          build             = params['build'],

--- a/kaedama.py
+++ b/kaedama.py
@@ -80,7 +80,10 @@ def main():
     config = config[ args.rule ]
 
     # Input query specifies the source of the input files
-    input_query   = config.get('input_query','').format(**locals())
+    input_         = config.get('input')
+    input_query    = input_.get('query','').format(**locals())
+    input_query_db = input_.get('db',None)
+    #input_query   = config.get('input_query','').format(**locals())
     runlist_query = config.get('runlist_query','').format(**locals())
     params        = config.get('params',None)
     filesystem    = config.get('filesystem',None)

--- a/kaedama.py
+++ b/kaedama.py
@@ -16,8 +16,8 @@ from slurp import daqc
 import sh
 import sys
 
-cursors = { 'daq':daqc,
-            'fc':fcc }
+from slurp import cursors
+
 
 #from simpleLogger import DEBUG, INFO, WARN, ERROR, CRITICAL
 import logging

--- a/slurp.py
+++ b/slurp.py
@@ -90,7 +90,8 @@ class SPhnxRule:
     script:            str            # Production script
     build:             str            # Build tag
     tag:               str            # Database tag
-    files:             str  = None    # FileCatalog DB query
+    files:             str  = None    # Input files query
+    filesdb:           str  = None    # Input files DB to query
     runlist:           str  = None    # Input run list query from daq
     job:               SPhnxCondorJob = SPhnxCondorJob()
     resubmit:          bool = False   # Set true if job should overwrite existing job

--- a/slurp.py
+++ b/slurp.py
@@ -387,9 +387,6 @@ def submit( rule, **kwargs ):
 
         # Strip out unused $(...) condor macros
         mymatching = []
-        if rule.runlist:
-            INFO("Detected filelist inputs... massage the matches...")
-
         for m in iter(matching):
             d = {}
             # massage the inputs from space to comma separated

--- a/slurp.py
+++ b/slurp.py
@@ -178,21 +178,6 @@ class SPhnxMatch:
         return { k: str(v) for k, v in asdict(self).items() if v is not None }
 
 
-def Xtable_exists( tablename ):
-    """
-    Returns true if the named table exists
-    """    
-    query = """
-    select exists ( 
-         select 1 from information_schema.tables where table_name='%s'
-    );
-    """%tablename
-
-    result = bool( fccro.execute( query ).fetchone()[0] )
-    fccro.execute( "select exists ( select 1 from information_schema.tables where table_name='production_setup' )" ).fetchone()
-
-    return result
-
 def table_exists( tablename ):
     """
     """ 
@@ -578,6 +563,16 @@ def matches( rule, kwargs={} ):
     if rule.runlist:
         rl_result = list( daqc.execute( rule.runlist ).fetchall() )
         rl_map = { r.runnumber : r for r in rl_result }
+
+    runlistfromfc = """
+    select 
+            'filecatalog/files' as source,
+            runnumber,
+            segment,
+            string_agg( distinct lfn ) as files
+    from files
+    where ...
+    """
 
     #
     # Build the list of output files for the transformation from the run and segment number in the filecatalog query.

--- a/slurp.py
+++ b/slurp.py
@@ -37,8 +37,8 @@ __rules__  = []
 fc = pyodbc.connect("DSN=FileCatalog")
 fcc = fc.cursor()
 
-fcro  = pyodbc.connect("DSN=FileCatalog;READONLY=True")
-fccro = fc.cursor()
+#fcro  = pyodbc.connect("DSN=FileCatalog;READONLY=True")
+fccro = fcc # fcro.cursor()
 
 daqdb = pyodbc.connect("DSN=daq;UID=phnxrc;SERVER=sphnxdaqdbreplica.sdcc.bnl.gov;READONLY=True");
 daqc = daqdb.cursor()

--- a/slurp.py
+++ b/slurp.py
@@ -567,7 +567,7 @@ def matches( rule, kwargs={} ):
             segment = f.segment
             if lfn_lists.get(run,None) == None:
                 lfn_lists[ f"'{run}-{segment}'" ] = f.files.split()
-                rng_lists[ f"'{run}-{segment}'" ] = getattr( f, 'fileranges', [] )
+                rng_lists[ f"'{run}-{segment}'" ] = getattr( f, 'fileranges', '' ).split()
             else:
                 # If we hit this result, then the db query has resulted in two rows with identical
                 # run numbers.  Violating the implicit submission schema.
@@ -691,6 +691,7 @@ def matches( rule, kwargs={} ):
 
         inputs_ = lfn_lists[f"'{run}-{seg}'"]
         ranges_ = rng_lists[f"'{run}-{seg}'"]
+        
 
         #
         # If the DST has been produced (and we make it to this point) we issue a warning that
@@ -713,7 +714,7 @@ def matches( rule, kwargs={} ):
 
             if ranges_:
                 myranges = ' '.join(ranges_)
-            
+
             
             # 
             # Build the rule-match data structure and immediately convert it to a dictionary.

--- a/slurp.py
+++ b/slurp.py
@@ -667,7 +667,7 @@ def matches( rule, kwargs={} ):
         inputs_ = None
         if fc_map and rl_map:
             (fdum, frun, fseg, ffiles, *frest) = fc_map[run]
-            (rdum, rrun, rseg, rfiles, rhosts, *rrest) = rl_map[run]
+            (rdum, rrun, rseg, rfiles, *rrest) = rl_map[run]
             ffiles=ffiles.split()
             rfiles=rfiles.split()
             test =  set(ffiles) ^ set(rfiles)

--- a/slurp.py
+++ b/slurp.py
@@ -587,10 +587,10 @@ def matches( rule, kwargs={} ):
     # we know that we do not have to produce it if it appears w/in the outputs list.
     #
     dsttype="%s_%s_%s"%(name,build,tag)  # dsttype aka name above
-    fc_check = list( fccro.execute("select filename,runnumber,segment from datasets where dsttype like '"+dsttype+"';").fetchall() )
     exists = {}
-    for check in fc_check:
-        exists[ check[0] ] = ( check[1], check[2] )  # key=filename, value=(run,seg)
+    for check in fcc.execute("select filename,runnumber,segment from datasets where filename like '"+dsttype+"%';"):
+        exists[ check.filename ] = ( check.runnumber, check.segment)  # key=filename, value=(run,seg)
+
 
     # 
     # The production setup will be unique based on (1) the specified analysis build, (2) the specified DB tag,
@@ -598,7 +598,7 @@ def matches( rule, kwargs={} ):
     #
     repo_dir  = payload #'/'.join(payload.split('/')[1:]) 
     repo_hash = sh.git('rev-parse','--short','HEAD',_cwd=payload).rstrip()
-    repo_url  = sh.git('config','--get','remote.origin.url',_cwd="MDC2/submit/rawdata/caloreco/rundir/").rstrip()
+    repo_url  = sh.git('config','--get','remote.origin.url',_cwd="MDC2/submit/rawdata/caloreco/rundir/").rstrip()  # TODO: fix hardcoded directory
 
     setup = fetch_production_setup( name, buildarg, tag, repo_url, repo_dir, repo_hash )
     

--- a/slurp.py
+++ b/slurp.py
@@ -43,6 +43,13 @@ fccro = fc.cursor()
 daqdb = pyodbc.connect("DSN=daq;UID=phnxrc;SERVER=sphnxdaqdbreplica.sdcc.bnl.gov;READONLY=True");
 daqc = daqdb.cursor()
 
+cursors = { 
+    'daq':daqc,
+    'fc':fccro,
+    'daqdb':daqc,
+    'filecatalog': fccro
+}
+
 verbose=0
 
 @dataclass

--- a/slurp.py
+++ b/slurp.py
@@ -569,13 +569,15 @@ def matches( rule, kwargs={} ):
     rl_map    = None
 
     if rule.files:
-        curs = cursors[ rule.filesdb ]
+        curs      = cursors[ rule.filesdb ]
         fc_result = list( curs.execute( rule.files ).fetchall() )
-        fc_map = { f[1] : f for f in fc_result }
+        fc_map = { f.runnumber : f for f in fc_result }
+        for fc in fc_result:
+            print( fc )
 
     if rule.runlist:
         rl_result = list( daqc.execute( rule.runlist ).fetchall() )
-        rl_map = { r[1] : r for r in rl_result }
+        rl_map = { r.runnumber : r for r in rl_result }
 
     #
     # Build the list of output files for the transformation from the run and segment number in the filecatalog query.
@@ -586,6 +588,8 @@ def matches( rule, kwargs={} ):
     # Build dictionary of DSTs existing in the datasets table of the file catalog.  For every DST that is in this list,
     # we know that we do not have to produce it if it appears w/in the outputs list.
     #
+    # TODO: This is potentially a big, long query.  Limit query to the existing set of proposed output files or the 
+    # list of runs...
     dsttype="%s_%s_%s"%(name,build,tag)  # dsttype aka name above
     exists = {}
     for check in fcc.execute("select filename,runnumber,segment from datasets where filename like '"+dsttype+"%';"):

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -95,14 +95,18 @@ DST_EVENT:
    # The {*_condition} parameters (run, seg, limit) are substituted by kaedama
    # based on (optional) command line options.
    #
+   # 1000 events per job
+   # number of segments calculated in flight
+   # first event in each segment will be 1000*segment
+   # 
    input:
       db: daqdb
       query: |-
          select 
-                'daqdb/filelist' as source, 
-                runnumber, 
-                0 as segment, 
-                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files 
+                'daqdb/filelist'                                        as source  , 
+                runnumber                                                          , 
+                generate_series( 0, max(lastevent)/1000 )               as segment , 
+                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
          from  
                 filelist
          where 

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -21,17 +21,11 @@ DST_CALOR:
      mem     :   2048MB                                                                  # memory requirement
      disk    :   2GB                                                                     # disk requirement
 
+   #
    # Database query to find input files.  Note that the {run_condition}, {seg_condition} and
    # {limit_condition} are defined in kaedama from command line arguments.  These should be 
    # left in the query.
-   #input_query: |-
-   #     select filename,runnumber,segment from datasets
-   #         where filename like 'DST_EVENT_auau23_ana393_2023p009-%'
-   ##     {run_condition} 
-   #     {seg_condition}
-   #     order by runnumber,segment
-   #     {limit_condition}
-
+   #
    input: 
      db: filecatalog
      query: |-
@@ -89,7 +83,7 @@ DST_EVENT:
      mem     :   4096MB   
 
    #
-   # input_query:
+   # input query:
    #
    # This builds a list of all runs known to the file catalog "datasets" table.
    # The query should return:
@@ -104,26 +98,6 @@ DST_EVENT:
    # The {*_condition} parameters (run, seg, limit) are substituted by kaedama
    # based on (optional) command line options.
    #   
-   #input_query: |-
-   #      select 
-   ##             'filecatalog/datasets'                                  as source  ,
-   #             runnumber                                                          ,
-   #             0                                                       as segment ,        
-   #             string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
-   #      from 
-   ##             datasets
-   #      where
-   #             dsttype='beam' and dataset='rawdata1008'
-   #      {run_condition} 
-   #      {seg_condition}
-   #      group by 
-   #             runnumber
-   #      order by 
-   #             runnumber
-   #      {limit_condition}
-   #      ;
-
-
    input:
       db: filecatalog
       query: |-

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -184,8 +184,8 @@ DST_EVENT:
 
    filesystem:
      outdir : "/sphenix/lustre01/sphnxpro/slurp/$$([$(run)/100])00"
-     logdir : "file:///sphenix/data/data02/sphnxpro/condorlogs/$$([$(run)/100])00"
-     condor :        "/sphenix/data/data02/sphnxpro/condorlogs/$$([$(run)/100])00"
+     logdir : "file:///sphenix/data/data02/sphnxpro/testlogs/$$([$(run)/100])00"
+     condor :        "/sphenix/data/data02/sphnxpro/testlogs/$$([$(run)/100])00"
 
    #
    # Again I note the need to ensure that the arguments are properly specified given the

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -98,15 +98,17 @@ DST_EVENT:
    # 1000 events per job
    # number of segments calculated in flight
    # first event in each segment will be 1000*segment
-   # 
+   # 		string_agg( distinct split_part(filename,'/',-1) || ':(' || firstevent || ',' || lastevent || ')', ' ' ) as fileranges 		
    input:
       db: daqdb
       query: |-
          select 
-                'daqdb/filelist'                                        as source  , 
-                runnumber                                                          , 
-                generate_series( 0, max(lastevent)/1000 )               as segment , 
-                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
+                'daqdb/filelist'                                                 as source  , 
+                runnumber                                                                   , 
+                generate_series( 0, max(lastevent)/1000 )                       as segment , 
+                string_agg( distinct split_part(filename,'/',-1), ' ' )    as files,   
+                string_agg( distinct split_part(filename,'/',-1) || ':' || firstevent || ':' || lastevent              , ' ' )    as fileranges
+
          from  
                 filelist
          where 
@@ -192,7 +194,7 @@ DST_EVENT:
    job:
      executable            : "{payload}/run.sh"
      user_job_wrapper      : "init.sh"
-     arguments             : "$(nevents) {outbase} {logbase} {outdir} $(run) $(ClusterId) $(ProcId) $(build) $(tag) $(inputs)"
+     arguments             : "$(nevents) {outbase} {logbase} {outdir} $(run) $(ClusterId) $(ProcId) $(build) $(tag) $(inputs) $(ranges)"
      output_destination    : 'file://{condor}'
      transfer_input_files  : "{payload},cups.py,init.sh,pull.py"
      output                : '{logbase}.condor.stdout'

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -69,6 +69,16 @@ DST_CALOR:
         order by runnumber,segment
         {limit_condition}
 
+   input: 
+     db: filecatalog
+     query: |-
+        select filename,runnumber,segment from datasets
+            where filename like 'DST_EVENT_auau23_ana393_2023p009-%'
+        {run_condition} 
+        {seg_condition}
+        order by runnumber,segment
+        {limit_condition}
+
    # Declares the directory where input files are found, output files are stored, and
    # log/condor files should be placed.
    filesystem:
@@ -132,6 +142,28 @@ DST_EVENT:
    # based on (optional) command line options.
    #   
    input_query: |-
+         select 
+                'filecatalog/datasets'                                  as source  ,
+                runnumber                                                          ,
+                0                                                       as segment ,        
+                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
+         from 
+                datasets
+         where
+                dsttype='beam' and dataset='rawdata1008'
+         {run_condition} 
+         {seg_condition}
+         group by 
+                runnumber
+         order by 
+                runnumber
+         {limit_condition}
+         ;
+
+
+   input:
+      db: filecatalog
+      query: |-
          select 
                 'filecatalog/datasets'                                  as source  ,
                 runnumber                                                          ,

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -92,32 +92,51 @@ DST_EVENT:
    # 3. A sequence number (a placeholder fixed at zero for event builders)
    # 4. And a space-separated list of logical filenames 
    #
-   # The input query below accesses the datasets table of the file catalog.
-   # The dsttype is "beam" and the dataset is rawdata1008.
-   #
    # The {*_condition} parameters (run, seg, limit) are substituted by kaedama
    # based on (optional) command line options.
-   #   
+   #
    input:
-      db: filecatalog
+      db: daqdb
       query: |-
          select 
-                'filecatalog/datasets'                                  as source  ,
-                runnumber                                                          ,
-                0                                                       as segment ,        
-                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
-         from 
-                datasets
-         where
-                dsttype='beam' and dataset='rawdata1008'
-         {run_condition} 
-         {seg_condition}
-         group by 
-                runnumber
-         order by 
-                runnumber
-         {limit_condition}
-         ;
+                'daqdb/filelist' as source, 
+                runnumber, 
+                0 as segment, 
+                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files 
+         from  
+                filelist
+         where 
+                filename     like '/bbox%' and
+                filename not like '%intt%' and
+                filename not like '%LL1%'  and
+                filename not like '%GL1%'  and
+                filename not like '%TPC%'  and
+                filename not like '%TPOT%' and                                                                                                                                                                            filename not like '%mvtx%' 
+                {run_condition}
+         group by runnumber
+         order by runnumber
+                {limit_condition}
+              ;              
+                
+#      db: filecatalog
+#      query: |-
+#         select 
+#                'filecatalog/datasets'                                  as source  ,
+#                runnumber                                                          ,
+#                0                                                       as segment ,        
+#                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
+#         from 
+#                datasets
+#         where
+#                dsttype='beam' and dataset='rawdata1008'
+#         {run_condition} 
+#         {seg_condition}
+#         group by 
+#                runnumber
+#         order by 
+#                runnumber
+#         {limit_condition}
+#         ;
 
    #
    # runlist_query:

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -1,41 +1,4 @@
 #__________________________________________________________________________________________________________________
-#___________________________________________________________________________________________________DST_PRESUBMIT__
-PRESUBMIT:
-  #
-  #
-  #
-  params: 
-    name: PRESUBMIT
-
-  presubmit:
-    db: 'daq'
-    query: |-
-        select 'daq/filelist'                                           as source  ,
-                runnumber                                                          ,
-                0                                                       as segment ,
-                string_agg( distinct split_part(filename,'/',-1), ',' ) as files   ,
-                string_agg( distinct hostname,',')                      as hosts   
-        from filelist
-        where filename     like '/bbox%' and
-              filename not like '%intt%' and
-              filename not like '%LL1%'  and
-              filename not like '%GL1%'  and
-              filename not like '%TPC%'  and 
-              filename not like '%TPOT%' and
-              filename not like '%mvtx%'
-              {run_condition}
-              group by runnumber
-              order by runnumber
-              {limit_condition}
-              ;
-
-    action: |-
-       ./presubmit_action.sh {query} 
-
-  
-
-
-#__________________________________________________________________________________________________________________
 #_______________________________________________________________________________________________________DST_CALOR__
 DST_CALOR:
 
@@ -61,13 +24,13 @@ DST_CALOR:
    # Database query to find input files.  Note that the {run_condition}, {seg_condition} and
    # {limit_condition} are defined in kaedama from command line arguments.  These should be 
    # left in the query.
-   input_query: |-
-        select filename,runnumber,segment from datasets
-            where filename like 'DST_EVENT_auau23_ana393_2023p009-%'
-        {run_condition} 
-        {seg_condition}
-        order by runnumber,segment
-        {limit_condition}
+   #input_query: |-
+   #     select filename,runnumber,segment from datasets
+   #         where filename like 'DST_EVENT_auau23_ana393_2023p009-%'
+   ##     {run_condition} 
+   #     {seg_condition}
+   #     order by runnumber,segment
+   #     {limit_condition}
 
    input: 
      db: filecatalog
@@ -141,24 +104,24 @@ DST_EVENT:
    # The {*_condition} parameters (run, seg, limit) are substituted by kaedama
    # based on (optional) command line options.
    #   
-   input_query: |-
-         select 
-                'filecatalog/datasets'                                  as source  ,
-                runnumber                                                          ,
-                0                                                       as segment ,        
-                string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
-         from 
-                datasets
-         where
-                dsttype='beam' and dataset='rawdata1008'
-         {run_condition} 
-         {seg_condition}
-         group by 
-                runnumber
-         order by 
-                runnumber
-         {limit_condition}
-         ;
+   #input_query: |-
+   #      select 
+   ##             'filecatalog/datasets'                                  as source  ,
+   #             runnumber                                                          ,
+   #             0                                                       as segment ,        
+   #             string_agg( distinct split_part(filename,'/',-1), ' ' ) as files
+   #      from 
+   ##             datasets
+   #      where
+   #             dsttype='beam' and dataset='rawdata1008'
+   #      {run_condition} 
+   #      {seg_condition}
+   #      group by 
+   #             runnumber
+   #      order by 
+   #             runnumber
+   #      {limit_condition}
+   #      ;
 
 
    input:

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -194,7 +194,7 @@ DST_EVENT:
    job:
      executable            : "{payload}/run.sh"
      user_job_wrapper      : "init.sh"
-     arguments             : "$(nevents) {outbase} {logbase} {outdir} $(run) $(ClusterId) $(ProcId) $(build) $(tag) $(inputs) $(ranges)"
+     arguments             : "$(nevents) {outbase} {logbase} {outdir} $(run) $(seg) $(ClusterId) $(ProcId) $(build) $(tag) $(inputs) $(ranges)"
      output_destination    : 'file://{condor}'
      transfer_input_files  : "{payload},cups.py,init.sh,pull.py"
      output                : '{logbase}.condor.stdout'

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -39,7 +39,7 @@ DST_CALOR:
    # Declares the directory where input files are found, output files are stored, and
    # log/condor files should be placed.
    filesystem:
-     outdir : "/sphenix/lustre01/sphnxpro/slurp/$$([$(run)/100])00"
+     outdir : "/sphenix/lustre01/sphnxpro/slurptest/$$([$(run)/100])00"
      logdir : "file:///sphenix/data/data02/sphnxpro/condorlogs/$$([$(run)/100])00"
      condor :        "/sphenix/data/data02/sphnxpro/condorlogs/$$([$(run)/100])00"
 
@@ -197,13 +197,10 @@ DST_EVENT:
      arguments             : "$(nevents) {outbase} {logbase} {outdir} $(run) $(ClusterId) $(ProcId) $(build) $(tag) $(inputs) $(ranges)"
      output_destination    : 'file://{condor}'
      transfer_input_files  : "{payload},cups.py,init.sh,pull.py"
-     transfer_output_files  : '$(name)_$(build)_$(tag)-$INT(run,%08d)-$INT(seg,%04d).out,$(name)_$(build)_$(tag)-$INT(run,%08d)-$INT(seg,%04d).err'
      output                : '{logbase}.condor.stdout'
      error                 : '{logbase}.condor.stderr'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"
      accounting_group_user : "sphnxpro"
-
-
-
-  
+     transfer_output_files : '$(name)_$(build)_$(tag)-$INT(run,%08d)-$INT(seg,%04d).out,$(name)_$(build)_$(tag)-$INT(run,%08d)-$INT(seg,%04d).err'  
+     priority : '3800'

--- a/sphenix_auau23.yaml
+++ b/sphenix_auau23.yaml
@@ -105,7 +105,7 @@ DST_EVENT:
          select 
                 'daqdb/filelist'                                                 as source  , 
                 runnumber                                                                   , 
-                generate_series( 0, max(lastevent)/1000 )                       as segment , 
+                generate_series( 0, max(lastevent)/{args.nevents} )                       as segment , 
                 string_agg( distinct split_part(filename,'/',-1), ' ' )    as files,   
                 string_agg( distinct split_part(filename,'/',-1) || ':' || firstevent || ':' || lastevent              , ' ' )    as fileranges
 
@@ -197,6 +197,7 @@ DST_EVENT:
      arguments             : "$(nevents) {outbase} {logbase} {outdir} $(run) $(ClusterId) $(ProcId) $(build) $(tag) $(inputs) $(ranges)"
      output_destination    : 'file://{condor}'
      transfer_input_files  : "{payload},cups.py,init.sh,pull.py"
+     transfer_output_files  : '$(name)_$(build)_$(tag)-$INT(run,%08d)-$INT(seg,%04d).out,$(name)_$(build)_$(tag)-$INT(run,%08d)-$INT(seg,%04d).err'
      output                : '{logbase}.condor.stdout'
      error                 : '{logbase}.condor.stderr'
      log                   : '{condor}/{logbase}.condor'


### PR DESCRIPTION
- Place the daqdb query on par with the datasets query
   - daqdb/filelist is authoritative for set of files created by the sPHENIX daq
   - filecatalog/datasets is authoritative for set of files created by downstream reconstruction codes
   - utilze an internal query to the filecatalog/files table to confirm that input files are present and ready for (further) reconstruction

- Input query now takes two fields.  
   - "db" specifies which database to query.  "query" specifies the query itself.
   - It is expected to return rows consisting of: dummy field, a run #, a sequence #, aggregated list of inputs, ... with event ranges
   - Each row returned will result in a condor job.  Inputs / ranges appended as the last arguments of the script

