### PR TITLE
Format specification for output directory.

### DIFF
--- a/slurp.py
+++ b/slurp.py
@@ -8,11 +8,12 @@ import uuid
 import os
 import pathlib
 import pprint
-import math
 import sh
 import argparse
 import datetime
 import time
+
+import math
 
 from slurptables import SPhnxProductionSetup
 from slurptables import SPhnxProductionStatus
@@ -383,7 +384,7 @@ def submit( rule, **kwargs ):
 
         # This is calling for a regex... 
         outdir = outdir.replace( "$$([", "{math.floorOPAR" ) # start of condor expr becomes start of python format expression
-        outdir = outdir.replace( "])",   "CPAR}" ) # end of condor expr ...
+        outdir = outdir.replace( "])",   "CPAR:06d}" ) # end of condor expr ...
         outdir = outdir.replace( "$(", "" )    # condor macro "run" becomes local variable run.... hork.
         outdir = outdir.replace( ")",  "" )
         outdir = outdir.replace( "OPAR", "(" )
@@ -392,7 +393,6 @@ def submit( rule, **kwargs ):
         outdir = f'f"{outdir}"'
         for run in runlist:
             pathlib.Path( eval(outdir) ).mkdir( parents=True, exist_ok=True )            
-
     
     submit_job = htcondor.Submit( jobd )
 


### PR DESCRIPTION
This is  a bit of a hack, but it gets the job done.  The output directory, log directory and condor file director should appear as a run range, formatted as

`run_%08d_%08d`.

The solution here is tied to the expression in the job definitions, and thus is pretty fragile.  I am planning to modify the job specification to be a little less hacky  and more flexible... which will necessitate one more change here.