### PR TITLE
Dbinputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ odbc.ini
 odbc_prod.ini
 odbc_test.ini
 slurp-examples
+meh

--- a/cups.py
+++ b/cups.py
@@ -356,10 +356,13 @@ def getinputs(args):
     seg=int(args.segment)
     id_ = getLatestId( tablename, dstname, run, seg )
     query = f"""
-    select inputs from {tablename} where id={id_}
+    select inputs from {tablename} where id={id_} limit 1
     """
-    result = statusdbr.execute( query ).fetchone()
-    print(result[0])
+    result = statusdbr.execute( query ).fetchone()    
+    flist = str(result[0]).split(' ')
+    for f in flist:
+        print(f)
+
 
 
 #_______________________________________________________________________________________________________

--- a/cups.py
+++ b/cups.py
@@ -359,7 +359,7 @@ def getinputs(args):
     select inputs from {tablename} where id={id_} limit 1
     """
     result = statusdbr.execute( query ).fetchone()    
-    flist = str(result[0]).split(' ')
+    flist = str(result[0]).split(',')
     for f in flist:
         print(f)
 

--- a/production-rules/DST_TRIGGERED_EVENT_run2pp_ana430_2024p007.yaml
+++ b/production-rules/DST_TRIGGERED_EVENT_run2pp_ana430_2024p007.yaml
@@ -50,7 +50,7 @@ DST_TRIGGERED_EVENT_run2pp_ana430_2024p007:
              (filename  like '/bbox%/%mbd%physics%-0000.prdf'      and lastevent>2 ) or
              (filename  like '/bbox%/%ZDC%physics%-0000.prdf'      and lastevent>2 )
            )
-           {run_condition} and run<=52331
+           {run_condition} and runnumber<=52331
 
          group by runnumber
 
@@ -84,7 +84,7 @@ DST_TRIGGERED_EVENT_run2pp_ana430_2024p007:
              (filename  like '/bbox%/%mbd%physics%.prdf'      and lastevent>2 ) or
              (filename  like '/bbox%/%ZDC%physics%.prdf'      and lastevent>2 )
            )
-           {run_condition} and run<=52331
+           {run_condition} and runnumber<=52331
 
          group by runnumber
 

--- a/production-rules/DST_TRIGGERED_EVENT_run2pp_ana435_2024p007.yaml
+++ b/production-rules/DST_TRIGGERED_EVENT_run2pp_ana435_2024p007.yaml
@@ -51,7 +51,7 @@ DST_TRIGGERED_EVENT_run2pp_ana435_2024p007:
              (filename  like '/bbox%/%ZDC%physics%-0000.prdf'      and lastevent>2 )
            )
            {run_condition}
-           and run>52331
+           and runnumber>52331
 
          group by runnumber
 
@@ -86,7 +86,7 @@ DST_TRIGGERED_EVENT_run2pp_ana435_2024p007:
              (filename  like '/bbox%/%ZDC%physics%.prdf'      and lastevent>2 )
            )
            {run_condition}
-           and run>52331
+           and runnumber>52331
 
          group by runnumber
 

--- a/slurp.py
+++ b/slurp.py
@@ -591,9 +591,11 @@ def submit( rule, maxjobs, **kwargs ):
             d = {}
             # massage the inputs from space to comma separated
             if m.get('inputs',None): 
-                m['inputs']= ','.join( m['inputs'].split() )
+                if args.dbinput: m['inputs']= 'dbinput'
+                else:            m['inputs']= ','.join( m['inputs'].split() )
             if m.get('ranges',None):
-                m['ranges']= ','.join( m['ranges'].split() )
+                if args.dbinput: m['ranges']= 'dbranges'
+                else:            m['ranges']= ','.join( m['ranges'].split() )
             for k,v in m.items():
                 if k in str(submit_job):
                     d[k] = v
@@ -1060,6 +1062,7 @@ arg_parser.add_argument( "--batch", default=False, action="store_true",help="Bat
 arg_parser.add_argument( '-u', '--unblock-state', nargs='*', dest='unblock',  choices=["submitting","submitted","started","running","evicted","failed","finished"] )
 arg_parser.add_argument( '-r', '--resubmit', dest='resubmit', default=False, action='store_true', 
                          help='Existing filecatalog entry does not block a job')
+arg_parser.add_argument( "--dbinput", default=False, action="store_true",help="Passes input filelist through the production status db rather than the argument list of the production script." )
 
 def parse_command_line():
     global blocking

--- a/slurp.py
+++ b/slurp.py
@@ -589,21 +589,22 @@ def submit( rule, maxjobs, **kwargs ):
         mymatching = []
         for m in iter(matching):
             d = {}
+
             # massage the inputs from space to comma separated
             if m.get('inputs',None): 
-                if args.dbinput: m['inputs']= 'dbinput'
-                else:            m['inputs']= ','.join( m['inputs'].split() )
+                m['inputs']= ','.join( m['inputs'].split() )
             if m.get('ranges',None):
-                if args.dbinput: m['ranges']= 'dbranges'
-                else:            m['ranges']= ','.join( m['ranges'].split() )
+                m['ranges']= ','.join( m['ranges'].split() )
+
             for k,v in m.items():
                 if k in str(submit_job):
                     d[k] = v
+                if args.dbinput: 
+                    d['inputs']= 'dbinput'            
+                    d['ranges']= 'dbranges'
+
             mymatching.append(d)        
             dispatched_runs.append( (d['run'],d['seg']) )
-
-            
-
                 
         run_submit_loop=30
         schedd_query = None


### PR DESCRIPTION
File lists can become arbitrarily long, pushing the argument list to the production script beyond the limit supported by linux.  This works around the issue by using the DB to provide the file list.