### PR TITLE
Cupsid rebase

### DIFF
--- a/cups.py
+++ b/cups.py
@@ -181,7 +181,6 @@ def started(args):
          execution_node='{node}'
     where id={id_}
     """    
-    #where dstname='{dstname}' and run={run} and segment={seg} and id={id_}
 
     if args.verbose:
         print(update)

--- a/cups.py
+++ b/cups.py
@@ -134,6 +134,10 @@ def getLatestId( tablename, dstname, run, seg ):
 
     cache="cups.cache"
 
+    cupsid=os.getenv('cupsid')
+    if cupsid and tablename=='production_status':
+        return cupsid
+
     result  = 0
     query=f"""
     select id,dstname from {tablename} where run={run} and segment={seg} order by id desc limit {MAXDSTNAMES};

--- a/slurp.py
+++ b/slurp.py
@@ -483,10 +483,6 @@ def insert_production_status( matching, setup, condor=[], state='submitting' ):
 
         values.append( f"('{dsttype}','{dstname}','{dstfile}',{run},{segment},0,'{dstfileinput}',{prod_id},{cluster},{process},'{status}', '{timestamp}', 0, '{node}' )" )
         
-
-        #statusdbw.execute(insert)
-        #statusdbw.commit()
-
     insvals = ','.join(values)
 
     insert = f"""

--- a/slurp.py
+++ b/slurp.py
@@ -657,10 +657,10 @@ def submit( rule, maxjobs, **kwargs ):
             
 
             INFO("... result")
-            result = submit_result.cluster()
+            result = submit_result.cluster()            
 
-            #INFO("... update")
-            #update_production_status( matching, setup, schedd_query, state="submitted" )
+            INFO("... update")
+            update_production_status( matching, setup, schedd_query, state="submitted" )
 
 
     else:

--- a/slurp.py
+++ b/slurp.py
@@ -337,7 +337,7 @@ def fetch_invalid_run_entry( dstname, run, seg ):
 def getLatestId( tablename, dstname, run, seg ):
 
     cache="cups.cache"
-
+    
     # We are limiting to the list of all productions for a given run,segment pair.
 
     result  = 0
@@ -648,8 +648,6 @@ def submit( rule, maxjobs, **kwargs ):
         cupsids = insert_production_status( matching, setup, [], state="submitting" ) 
         for i,m in zip(cupsids,mymatching):
             m['cupsid']=str(i)
-
-        pprint.pprint(mymatching)
 
         INFO("Submitting the jobs to the cluster")
         submit_result = schedd.submit(submit_job, itemdata=iter(mymatching))  # submit one job for each item in the itemdata

--- a/slurp.py
+++ b/slurp.py
@@ -639,7 +639,9 @@ def submit( rule, maxjobs, **kwargs ):
                 
         run_submit_loop=30
         schedd_query = None
-
+        
+        INFO("... insert")
+        insert_production_status( matching, setup, [], state="submitting" ) 
 
         INFO("Submitting the jobs to the cluster")
         submit_result = schedd.submit(submit_job, itemdata=iter(mymatching))  # submit one job for each item in the itemdata
@@ -653,8 +655,6 @@ def submit( rule, maxjobs, **kwargs ):
         INFO("Insert and update the production_status")
         if ( schedd_query ):
             
-            INFO("... insert")
-            insert_production_status( matching, setup, schedd_query, state="submitted" ) 
 
             INFO("... result")
             result = submit_result.cluster()

--- a/slurp.py
+++ b/slurp.py
@@ -633,7 +633,6 @@ def submit( rule, maxjobs, **kwargs ):
             projection=["ClusterId", "ProcId", "Out", "UserLog", "Args" ]
         )
 
- 
         # Update DB IFF we have a valid submission
         INFO("Insert and update the production_status")
         if ( schedd_query ):

--- a/slurp.py
+++ b/slurp.py
@@ -397,7 +397,7 @@ def update_production_status( matching, setup, condor, state ):
 
     statusdbw.commit()
 
-def insert_production_status( matching, setup, condor, state ):
+def insert_production_status( matching, setup, condor=[], state='submitting' ):
 
     # Condor map contains a dictionary keyed on the "output" field of the job description.
     # The map contains the cluster ID, the process ID, the arguments, and the output log.

--- a/slurp.py
+++ b/slurp.py
@@ -461,6 +461,7 @@ def insert_production_status( matching, setup, condor, state ):
         insert=f"""
         insert into production_status
                (dsttype, dstname, dstfile, run, segment, nsegments, inputs, prod_id, cluster, process, status, submitting, nevents, submission_host )
+
         values ('{dsttype}','{dstname}','{dstfile}',{run},{segment},0,'{dstfileinput}',{prod_id},{cluster},{process},'{status}', '{timestamp}', 0, '{node}' )
         """
 
@@ -477,9 +478,16 @@ def insert_production_status( matching, setup, condor, state ):
            (dsttype, dstname, dstfile, run, segment, nsegments, inputs, prod_id, cluster, process, status, submitting, nevents, submission_host )
     values 
            {insvals}
+
+    returning id
     """
     statusdbw.execute(insert)
     statusdbw.commit()
+
+    result=[ int(x.id) for x in statusdbw.fetchall() ]
+
+    return result
+    
 
         
 

--- a/slurp.py
+++ b/slurp.py
@@ -464,10 +464,6 @@ def insert_production_status( matching, setup, condor=[], state='submitting' ):
             cluster = condor_map[ key.lower() ][ 'ClusterId' ]
             process = condor_map[ key.lower() ][ 'ProcId'    ]
         except KeyError:
-            ERROR("Key Error getting cluster and/or process number from the class ads map.")
-            ERROR(f"  key={key}")
-            pprint.pprint( condor_map )
-            ERROR("Assuming this is an issue with condor, setting cluster=0, process=0 and trying to continue...")
             cluster = 0
             process = 0
 

--- a/slurp.py
+++ b/slurp.py
@@ -403,7 +403,6 @@ def update_production_status( matching, setup, condor, state ):
         
         dsttype=setup.name
         dstname=setup.name+'_'+setup.build.replace(".","")+'_'+setup.dbtag
-        #dstfile=dstname+'-%08i-%04i'%(run,segment)
         dstfile=( dstname + '-' + RUNFMT + '-' + SEGFMT ) % (run,segment)
 
         # 1s time resolution
@@ -432,11 +431,8 @@ def insert_production_status( matching, setup, condor=[], state='submitting' ):
         procId    = ad['ProcId']
         out       = ad['Out'].split('/')[-1]   # discard anything that looks like a filepath
         ulog      = ad['UserLog'].split('/')[-1] 
-        #args      = ad['Args']
-        #key      = out.split('.')[0].lower()  # lowercase b/c referenced by file basename
         key       = ulog.split('.')[0].lower()  # lowercase b/c referenced by file basename
 
-        #condor_map[key]= { 'ClusterId':clusterId, 'ProcId':procId, 'Out':out, 'Args':args, 'UserLog':ulog }
         condor_map[key]= { 'ClusterId':clusterId, 'ProcId':procId, 'Out':out, 'UserLog':ulog }
 
 

--- a/slurp.py
+++ b/slurp.py
@@ -560,6 +560,9 @@ def submit( rule, maxjobs, **kwargs ):
     INFO("Get the job dictionary")
     jobd = rule.job.dict()
 
+    # Append $(cupsid) as the last argument
+    jobd['arguments'] = jobd['arguments'] + ' $(cupsid)'
+
 
     #
     # Make target output directories.  We abuse the python string formatting facility
@@ -640,8 +643,13 @@ def submit( rule, maxjobs, **kwargs ):
         run_submit_loop=30
         schedd_query = None
         
+        # Insert jobs into the production status table and add the ID to the dictionary
         INFO("... insert")
-        insert_production_status( matching, setup, [], state="submitting" ) 
+        cupsids = insert_production_status( matching, setup, [], state="submitting" ) 
+        for i,m in zip(cupsids,mymatching):
+            m['cupsid']=str(i)
+
+        pprint.pprint(mymatching)
 
         INFO("Submitting the jobs to the cluster")
         submit_result = schedd.submit(submit_job, itemdata=iter(mymatching))  # submit one job for each item in the itemdata


### PR DESCRIPTION
Pass the ID of the production status row as the last argument to the user script.   When the
user exports cupsid, cups will pickup the row information that was passed in through the command
line.  This obviates the need to look it up in the database, removing a point of failure when looking up 
data on the replicas.