### PR TITLE
Rawdata catalog

### DIFF
--- a/slurp.py
+++ b/slurp.py
@@ -104,6 +104,13 @@ except:
     daqdb = None
     daqc = None
 
+
+
+rawdr_ = pyodbc.connect("DSN=RawdataCatalog_read;UID=phnxrc;READONLY=True")
+rawdr  = rawdr_.cursor()
+printDbInfo( rawdr_, "RAW database [reads]" )
+
+
 #print(f"ProductionStatus [RO]: timeout {statusdbr_.timeout}s")
 #print(f"ProductionStatus [Wr]: timeout {statusdbw_.timeout}s")
 #print(f"FileCatalog [RO]:      timeout {fcro.timeout}s")

--- a/slurp.py
+++ b/slurp.py
@@ -121,7 +121,8 @@ cursors = {
     'fc':fccro,
     'daqdb':daqc,
     'filecatalog': fccro,
-    'status' : statusdbr
+    'status' : statusdbr,
+    'raw':rawdr,
 }
 
 verbose=0

--- a/slurp.py
+++ b/slurp.py
@@ -123,6 +123,7 @@ cursors = {
     'filecatalog': fccro,
     'status' : statusdbr,
     'raw':rawdr,
+    'rawdr':rawdr,
 }
 
 verbose=0


### PR DESCRIPTION
Input queries can be mapped to the RawdataCatalog via 'db: raw'.  This is backwards compatible with the daqdb.
(In principle we can remap daqdb --> raw and not have to touch existing workflows...)