### PR TITLE
Alma 9 Linux Support

### DIFF
--- a/jobwrapper.sh
+++ b/jobwrapper.sh
@@ -4,14 +4,19 @@
 hostname
 echo $@
 
-# Job wrapper will start with sphenix_setup level at NEW
-source /opt/sphenix/core/bin/sphenix_setup.sh -n new
 
 export userscript=$1       # this is the executable script
 export cupsid=${@: -1:1}                         # this is the ID of the job on the production system
 export payload=( `echo ${@: -2:1} | tr ","  " "` ) # comma sep list --> array of files to stage in
 export subdir=${@: -3:1}                         # ... relative to the submission directory
 
+myArgs=( "$@")
+shift
+userArgs=( "$@" )
+
+source /opt/sphenix/core/bin/sphenix_setup.sh -n new
+echo Argument list is now completely fubared
+echo $@
 echo userscript: ${userscript}
 echo cupsid:     ${cupsid}
 echo payload:    ${payload[@]}
@@ -22,17 +27,13 @@ for i in ${payload[@]}; do
     cp --verbose $subdir/$i . 
 done
 
-shift                      # everything else gets passed to the executable
 
 chmod u+x ${userscript}
 
-singularity exec -B /home -B /direct/sphenix+u -B /gpfs02 -B /sphenix/u -B /sphenix/lustre01 -B /sphenix/user  -B /sphenix/data/data02 /cvmfs/sphenix.sdcc.bnl.gov/singularity/rhic_sl7.sif ./${userscript} $*
+singularity exec -B /home -B /direct/sphenix+u -B /gpfs02 -B /sphenix/u -B /sphenix/lustre01 -B /sphenix/user  -B /sphenix/data/data02 /cvmfs/sphenix.sdcc.bnl.gov/singularity/rhic_sl7.sif ./${userscript} ${userArgs[@]}
 
-#echo source ${userscript} ${@}
-#     source ${userscript} ${@}
-
-} 
-#>& /sphenix/data/data02/sphnxpro/production-testbed/physics/run2pp/DST_STREAMING_EVENT_run2pp/ana444_2024p007/run_00053800_00053900/jobwrapper.containertest.log
+}
+#>& /sphenix/data/data02/sphnxpro/production-testbed/jobwrapper.log
 
    
 

--- a/jobwrapper.sh
+++ b/jobwrapper.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash 
+{
+
+echo $@
+
+# Job wrapper will start with sphenix_setup level at NEW
+source /opt/sphenix/core/bin/sphenix_setup.sh -n new
+
+export userscript=$1       # this is the executable script
+export cupsid=${@: -1:1}                         # this is the ID of the job on the production system
+export payload=(`echo ${@: -2:1} | tr ","  " "`) # comma sep list --> array of files to stage in
+export subdir=${@: -3:1}                         # ... relative to the submission directory
+
+echo userscript: ${userscript}
+echo cupsid:     ${cupsid}
+echo payload:    ${payload[@]}
+echo subdir:     ${subdir}
+
+# stage in the payload files
+for i in ${payload[@]}; do
+    cp --verbose $subdir/$i . 
+done
+
+shift                      # everything else gets passed to the executable
+
+chmod u+x ${userscript}
+
+echo source ${userscript} ${@}
+     source ${userscript} ${@}
+
+} >& /sphenix/data/data02/sphnxpro/production-testbed/physics/run2pp/DST_STREAMING_EVENT_run2pp/ana444_2024p007/run_00053800_00053900/jobwrapper.${cupsid}.log
+
+   
+
+

--- a/jobwrapper.sh
+++ b/jobwrapper.sh
@@ -4,7 +4,6 @@
 hostname
 echo $@
 
-
 export userscript=$1       # this is the executable script
 export cupsid=${@: -1:1}                         # this is the ID of the job on the production system
 export payload=( `echo ${@: -2:1} | tr ","  " "` ) # comma sep list --> array of files to stage in
@@ -14,9 +13,26 @@ myArgs=( "$@")
 shift
 userArgs=( "$@" )
 
+OS=$( hostnamectl | awk '/Operating System/{ print $3" "$4 }' )
+echo "Setting up SLURP for ${OS}"
+
 source /opt/sphenix/core/bin/sphenix_setup.sh -n new
+export PATH=${PATH}:${HOME}/bin
+
+if [[ $OS =~ "Alma" ]]; then
+   echo "Rejiggering python path"
+   export PYTHONPATH=/opt/sphenix/core/lib/python3.9/site-packages
+   alias python=/usr/bin/python
+   alias pip=/opt/sphenix/core/bin/pip3.9
+fi
+
 echo Argument list is now completely fubared
 echo $@
+
+# Job wrapper will start with sphenix_setup level at NEW
+#source /opt/sphenix/core/bin/sphenix_setup.sh -n new
+
+
 echo userscript: ${userscript}
 echo cupsid:     ${cupsid}
 echo payload:    ${payload[@]}
@@ -26,7 +42,6 @@ echo subdir:     ${subdir}
 for i in ${payload[@]}; do
     cp --verbose $subdir/$i . 
 done
-
 
 chmod u+x ${userscript}
 

--- a/jobwrapper.sh
+++ b/jobwrapper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash 
-{
+{ 
 
 hostname
 echo $@

--- a/jobwrapper.sh
+++ b/jobwrapper.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash 
 {
 
+hostname
 echo $@
 
 # Job wrapper will start with sphenix_setup level at NEW
@@ -8,7 +9,7 @@ source /opt/sphenix/core/bin/sphenix_setup.sh -n new
 
 export userscript=$1       # this is the executable script
 export cupsid=${@: -1:1}                         # this is the ID of the job on the production system
-export payload=(`echo ${@: -2:1} | tr ","  " "`) # comma sep list --> array of files to stage in
+export payload=( `echo ${@: -2:1} | tr ","  " "` ) # comma sep list --> array of files to stage in
 export subdir=${@: -3:1}                         # ... relative to the submission directory
 
 echo userscript: ${userscript}
@@ -25,10 +26,13 @@ shift                      # everything else gets passed to the executable
 
 chmod u+x ${userscript}
 
-echo source ${userscript} ${@}
-     source ${userscript} ${@}
+singularity exec -B /home -B /direct/sphenix+u -B /gpfs02 -B /sphenix/u -B /sphenix/lustre01 -B /sphenix/user  -B /sphenix/data/data02 /cvmfs/sphenix.sdcc.bnl.gov/singularity/rhic_sl7.sif ./${userscript} $*
 
-} >& /sphenix/data/data02/sphnxpro/production-testbed/physics/run2pp/DST_STREAMING_EVENT_run2pp/ana444_2024p007/run_00053800_00053900/jobwrapper.${cupsid}.log
+#echo source ${userscript} ${@}
+#     source ${userscript} ${@}
+
+} 
+#>& /sphenix/data/data02/sphnxpro/production-testbed/physics/run2pp/DST_STREAMING_EVENT_run2pp/ana444_2024p007/run_00053800_00053900/jobwrapper.containertest.log
 
    
 

--- a/jobwrapper.sh
+++ b/jobwrapper.sh
@@ -43,6 +43,11 @@ for i in ${payload[@]}; do
     cp --verbose $subdir/$i . 
 done
 
+if [ -e odbc.ini ]; then
+export ODBCINI=./odbc.ini
+fi
+
+
 chmod u+x ${userscript}
 
 singularity exec -B /home -B /direct/sphenix+u -B /gpfs02 -B /sphenix/u -B /sphenix/lustre01 -B /sphenix/user  -B /sphenix/data/data02 /cvmfs/sphenix.sdcc.bnl.gov/singularity/rhic_sl7.sif ./${userscript} ${userArgs[@]}

--- a/kaedama.py
+++ b/kaedama.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/python 
+# /usr/bin/env python
 
 import cProfile
 import slurp

--- a/kaedama.py
+++ b/kaedama.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python 
-# /usr/bin/env python
+#!/usr/bin/env python 
 
 import cProfile
 import slurp

--- a/setup
+++ b/setup
@@ -1,3 +1,17 @@
+OS=$( hostnamectl | awk '/Operating System/{ print $3" "$4 }' )
+echo "Setting up SLURP for ${OS}"
+
 source /opt/sphenix/core/bin/sphenix_setup.sh -n new
-export PATH=${PATH}:${HOME}/bin
+export PATH=/usr/bin:${PATH}:${HOME}/bin
 export ODBCINI=./odbc.ini
+
+if [[ $OS =~ "Alma" ]]; then
+   echo "Rejiggering python path"
+   export PYTHONPATH=/opt/sphenix/core/lib/python3.9/site-packages
+   alias python=/usr/bin/python
+   alias pip=/opt/sphenix/core/bin/pip3.9
+fi
+
+
+
+

--- a/slurp.py
+++ b/slurp.py
@@ -189,7 +189,7 @@ class SPhnxCondorJob:
     Condor submission job template.
     """
     universe:              str = "vanilla"
-    executable:            str = "$(script)"    
+    executable:            str = "jobwrapper.sh"    
     arguments:             str = "$(nevents) $(run) $(seg) $(lfn) $(indir) $(dst) $(outdir) $(buildarg) $(tag) $(ClusterId) $(ProcId)"
     batch_name:            str = "$(name)_$(build)_$(tag)"
     #output:                str = f"$(name)_$(build)_$(tag)-$INT(run,{RUNFMT})-$INT(seg,{SEGFMT}).stdout"
@@ -622,6 +622,12 @@ def submit( rule, maxjobs, **kwargs ):
 
     INFO("Get the job dictionary")
     jobd = rule.job.dict()
+
+    # If we are using a wrapper, the user script becomes the first argument
+    if jobd['executable']=='jobwrapper.sh':
+        INFO(f"Setting up general jobwrapper script.  Adding user script {rule.script} as first argument")
+        jobd['arguments']= rule.script + ' ' + jobd['arguments']
+        INFO(f"  {jobd['arguments']}")
 
     # Append $(cupsid) as the last argument
     jobd['arguments'] = jobd['arguments'] + ' $(cupsid)'


### PR DESCRIPTION
Provides a general 'jobwrapper.sh' script.   Sets 'jobwrapper.sh' as the default executable for the condor job.  When the jobwrapper is used, the argument list is prepended with the name of the user's production script (specified in the params block).  The job wrapper expects that the last three arguments specified are the PWD, the list of payloads relative to the PWD, and the ID of the production status line that manages the job.  

Payload files (which should include the user's production script) will be staged in.

The job wrapper runs the user's production script in a container.

