### PR TITLE
Remove sphenix run name (eg run2pp) from the last directory name

### DIFF
--- a/kaedama.py
+++ b/kaedama.py
@@ -66,11 +66,18 @@ arg_parser.add_argument( '--print-query',dest='printquery',help="Print the query
 
 # TODO: physics/run2pp/ana449_2024p008/”run range”/DST_TRKR_CLUSTER
 #       runtype runname build_tag  runrange DST
+#_default_filesystem = {
+#        'outdir'  :           "/sphenix/lustre01/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
+#    ,   'logdir'  : "file:///sphenix/data/data02/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
+#    ,   'histdir' :       "/sphenix/data/data02/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
+#    ,   'condor'  :                                 "/tmp/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
+#}
+
 _default_filesystem = {
-        'outdir'  :           "/sphenix/lustre01/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
-    ,   'logdir'  : "file:///sphenix/data/data02/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
-    ,   'histdir' :       "/sphenix/data/data02/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
-    ,   'condor'  :                                 "/tmp/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/$(name)"
+        'outdir'  :           "/sphenix/lustre01/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/{leafdir}"
+    ,   'logdir'  : "file:///sphenix/data/data02/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/{leafdir}"
+    ,   'histdir' :       "/sphenix/data/data02/sphnxpro/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/{leafdir}"
+    ,   'condor'  :                                 "/tmp/production/$(runtype)/$(runname)/$(build)_$(tag)/run_$(rungroup)/{leafdir}"
 }
 
 

--- a/slurp.py
+++ b/slurp.py
@@ -635,12 +635,6 @@ def submit( rule, maxjobs, **kwargs ):
     leafdir = rule.name.replace( f'_{rule.runname}', "" )
     jobd['arguments'] = jobd['arguments'].replace( '{leafdir}', leafdir )
 
-    pprint.pprint( jobd )
-
-    #print( rule.name )
-    #print( rule.runname )
-    #print( leafdir )
-
 
     INFO("Passing job to htcondor.Submit")
     submit_job = htcondor.Submit( jobd )
@@ -762,10 +756,6 @@ def submit( rule, maxjobs, **kwargs ):
 
             # submits the job to condor
             INFO("... submitting to condor")
-
-            pprint.pprint(mymatching)
-
-            pprint.pprint( submit_job )
 
             submit_result = schedd.submit(submit_job, itemdata=iter(mymatching))  # submit one job for each item in the itemdata
             # commits the insert done above

--- a/slurp.py
+++ b/slurp.py
@@ -632,6 +632,16 @@ def submit( rule, maxjobs, **kwargs ):
     # Append $(cupsid) as the last argument
     jobd['arguments'] = jobd['arguments'] + ' $(cupsid)'
 
+    leafdir = rule.name.replace( f'_{rule.runname}', "" )
+    jobd['arguments'] = jobd['arguments'].replace( '{leafdir}', leafdir )
+
+    pprint.pprint( jobd )
+
+    #print( rule.name )
+    #print( rule.runname )
+    #print( leafdir )
+
+
     INFO("Passing job to htcondor.Submit")
     submit_job = htcondor.Submit( jobd )
     if verbose>0:
@@ -670,6 +680,8 @@ def submit( rule, maxjobs, **kwargs ):
             runtype='none'
             d['runtype']='unset'
             d['runname']=rule.runname
+
+            leafdir=m["name"].replace(f"_{rule.runname}","")
 
             # massage the inputs from space to comma separated
             if m.get('inputs',None): 
@@ -752,6 +764,8 @@ def submit( rule, maxjobs, **kwargs ):
             INFO("... submitting to condor")
 
             pprint.pprint(mymatching)
+
+            pprint.pprint( submit_job )
 
             submit_result = schedd.submit(submit_job, itemdata=iter(mymatching))  # submit one job for each item in the itemdata
             # commits the insert done above


### PR DESCRIPTION
Directory name is generated by condor via condor macros, but we don't have a convenient one defined for the name of the DST minus the run name.   So we need to move this logic into the production system,
stripping the sphenix run name from the "slurp name" of the DST.  This needs to be done at two points.
First when we create the condor job.  Second when we are creating the itemdata passed to condor.  The
latter is involved in the creation of the directory structure on disk.