### PR TITLE
Handle mixed build and tag

### DIFF
--- a/slurp.py
+++ b/slurp.py
@@ -977,9 +977,6 @@ def matches( rule, kwargs={} ):
     else:
         INFO("Building lfn2pfn map from filecatalog")
 
-        # TODO FIX: The build and tag should be the build / tag of the input list
-        #           Can we use the lfn_lists that we built above?
-
         for mydataset in input_datasets.keys():
         
             fcquery=f"""

--- a/slurp.py
+++ b/slurp.py
@@ -111,12 +111,6 @@ rawdr_ = pyodbc.connect("DSN=RawdataCatalog_read;UID=phnxrc;READONLY=True")
 rawdr  = rawdr_.cursor()
 printDbInfo( rawdr_, "RAW database [reads]" )
 
-
-#print(f"ProductionStatus [RO]: timeout {statusdbr_.timeout}s")
-#print(f"ProductionStatus [Wr]: timeout {statusdbw_.timeout}s")
-#print(f"FileCatalog [RO]:      timeout {fcro.timeout}s")
-#print(f"DaqDB [RO]:            timeout {daqdb.timeout}s")
-
 cursors = { 
     'daq':rawdr,
     'fc':fccro,
@@ -141,8 +135,6 @@ cnxn_string_map = {
 }
 
 def dbQuery( cnxn_string, query, ntries=10 ):
-
-    print(f"dbQuery {cnxn_string}")
 
     # Some guard rails
     assert( 'delete' not in query.lower() )    
@@ -945,7 +937,6 @@ def matches( rule, kwargs={} ):
                 
             # Drop the run and segment numbers and leading stuff and just pull the datasets
             for fn in f.files.split():
-                print(fn)
                 base1 = fn.split('-')[0]
                 base2 = base1.split('_')[-2:]
                 input_datasets[ '_'.join(base2) ] = 1


### PR DESCRIPTION
Previously when we built the map between the logical filenames and the physical file location we assumed that the input and output datasets (build + tag) were the same.  This PR lifts that limitation.  The dataset for each input file is recorded, and the catalog query for the physical file locations will be performed for each unique dataset in the input list.

For the cases where the input filename does not conform to the production naming convention, e.g. we are dealing with raw event files from the daq, we will need to do a direct lookup on the filesystem using the 'direct_path' directive in the input query.